### PR TITLE
fix(scrollview): honor padded viewport

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,6 +234,16 @@ endif()
 
 option(UI_CORE_BUILD_INTERNAL_TESTS
     "Build internal regression test targets when test/ is available" ON)
+if(UI_CORE_BUILD_INTERNAL_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/src/scroll_view_layout_test.cpp")
+    add_executable(scroll_view_layout_test EXCLUDE_FROM_ALL
+        test/src/scroll_view_layout_test.cpp
+    )
+    target_compile_definitions(scroll_view_layout_test PRIVATE
+        UNICODE _UNICODE WIN32_LEAN_AND_MEAN NOMINMAX)
+    target_include_directories(scroll_view_layout_test PRIVATE src/ui)
+    target_link_libraries(scroll_view_layout_test PRIVATE core-ui)
+endif()
+
 if(UI_CORE_BUILD_INTERNAL_TESTS AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/src/svg_normalize_test.cpp")
     add_executable(svg_normalize_test EXCLUDE_FROM_ALL
         test/src/svg_normalize_test.cpp

--- a/src/ui/controls.cpp
+++ b/src/ui/controls.cpp
@@ -2124,8 +2124,20 @@ void ScrollViewWidget::SetContent(WidgetPtr content) {
     if (content_) AddChild(content_);
 }
 
+D2D1_RECT_F ScrollViewWidget::ViewportRect() const {
+    const float left = rect.left + padL;
+    const float top = rect.top + padT;
+    return {
+        left,
+        top,
+        std::max(left, rect.right - padR),
+        std::max(top, rect.bottom - padB),
+    };
+}
+
 float ScrollViewWidget::VisibleHeight() const {
-    return rect.bottom - rect.top;
+    const auto viewport = ViewportRect();
+    return viewport.bottom - viewport.top;
 }
 
 bool ScrollViewWidget::NeedsScrollbar() const {
@@ -2139,12 +2151,13 @@ void ScrollViewWidget::ClampScroll() {
 
 D2D1_RECT_F ScrollViewWidget::ThumbRect() const {
     if (!NeedsScrollbar()) return {};
+    const auto viewport = ViewportRect();
     float visH = VisibleHeight();
     float ratio = visH / contentHeight_;
-    float thumbH = std::max(20.0f, visH * ratio);
+    float thumbH = std::min(visH, std::max(20.0f, visH * ratio));
     float maxScroll = contentHeight_ - visH;
     float scrollRatio = maxScroll > 0 ? scrollY_ / maxScroll : 0;
-    float thumbY = rect.top + scrollRatio * (visH - thumbH);
+    float thumbY = viewport.top + scrollRatio * (visH - thumbH);
     float tw = ThumbWidth();
     float inset = 2.0f;  // avoid resize border
     return {rect.right - tw - inset, thumbY, rect.right - inset, thumbY + thumbH};
@@ -2153,24 +2166,20 @@ D2D1_RECT_F ScrollViewWidget::ThumbRect() const {
 void ScrollViewWidget::DoLayout() {
     if (!content_) return;
 
-    /* Build 110 (L29 follow-up): 应用 padding 给 content 区域. 之前
-     * visW/visH/content.rect 直接用 sv.rect, padL/padT/padR/padB 字段被
-     * 忽略, .uix 写 `padding: 24px 28px` 视觉上没起作用 — caller 的内容
-     * 贴 ScrollView 边. 改成跟 VBox/HBox 同款行为: content 起点偏 padding,
-     * 可用宽高扣 padding. */
-    float visW = (rect.right - padR) - (rect.left + padL);
-    float visH = (rect.bottom - padB) - (rect.top + padT);
+    const auto viewport = ViewportRect();
+    const float visW = viewport.right - viewport.left;
+    const float visH = viewport.bottom - viewport.top;
 
     // First pass: layout content at full height to measure actual needed height
     // Give it a tall rect so VBox can place all children without compression
     float estimatedH = std::max(content_->SizeHint().height, visH);
-    content_->rect = {rect.left + padL, rect.top + padT,
-                        rect.left + padL + visW,
-                        rect.top + padT + estimatedH};
+    content_->rect = {viewport.left, viewport.top,
+                        viewport.right,
+                        viewport.top + estimatedH};
     content_->DoLayout();
 
     // Measure actual content height from children bounds (EXCLUDING content_ itself)
-    float maxBottom = rect.top + padT;
+    float maxBottom = viewport.top;
     std::function<void(Widget*)> measure = [&](Widget* w) {
         if (!w->visible) return;
         if (w->rect.bottom > maxBottom) maxBottom = w->rect.bottom;
@@ -2178,9 +2187,7 @@ void ScrollViewWidget::DoLayout() {
     };
     // 只 measure 子元素的 bounds，不包含 content_ 自己的 rect.bottom（那是 estimatedH，非真实内容）
     for (auto& c : content_->Children()) measure(c.get());
-    /* contentHeight_ 含 padT 但不含 padB — 内容 + 上 padding 是滚动可视范围,
-     * 下 padding 通过 visH 已经扣过 (caller 想要的"末尾留白"自然出现). */
-    contentHeight_ = std::max(maxBottom - rect.top, visH);
+    contentHeight_ = std::max(maxBottom - viewport.top, visH);
 
 
     // Scrollbar overlays content (absolute positioning, no space reserved)
@@ -2188,16 +2195,17 @@ void ScrollViewWidget::DoLayout() {
     ClampScroll();
 
     // Final layout with correct scroll offset and width
-    content_->rect = {rect.left + padL, rect.top + padT - scrollY_,
-                        rect.left + padL + cw,
-                        rect.top + padT - scrollY_ + contentHeight_};
+    content_->rect = {viewport.left, viewport.top - scrollY_,
+                        viewport.left + cw,
+                        viewport.top - scrollY_ + contentHeight_};
     content_->DoLayout();
 }
 
 void ScrollViewWidget::OnDraw(Renderer& r) {
     Widget::OnDraw(r);
-    // Content is drawn in DrawTree with clipping — not here.
+}
 
+void ScrollViewWidget::DrawScrollbar(Renderer& r) {
     // Scrollbar (overlay, no track background)
     if (NeedsScrollbar()) {
         auto thumb = ThumbRect();
@@ -2213,13 +2221,13 @@ void ScrollViewWidget::OnDraw(Renderer& r) {
 
 void ScrollViewWidget::DrawTree(Renderer& r) {
     if (!visible) return;
-    // Draw background + scrollbar
+    // Paint the background, clipped content, then the overlay scrollbar.
     OnDraw(r);
     paintedOnce_ = true;   // L45: mount-phase transition gate
-    // Draw content inside clip region — only once
-    r.PushClip(rect);
+    r.PushClip(ViewportRect());
     if (content_) content_->DrawTree(r);
     r.PopClip();
+    DrawScrollbar(r);
     // Skip Widget::DrawTree's default children iteration (content is already drawn)
 }
 
@@ -2234,7 +2242,9 @@ bool ScrollViewWidget::OnMouseWheel(const MouseEvent& e) {
 }
 
 bool ScrollViewWidget::OnMouseDown(const MouseEvent& e) {
-    if (NeedsScrollbar() && e.x >= rect.right - kBarSpace - 2 && e.x < rect.right - 2) {
+    const auto viewport = ViewportRect();
+    if (NeedsScrollbar() && e.y >= viewport.top && e.y < viewport.bottom &&
+        e.x >= rect.right - kBarSpace - 2 && e.x < rect.right - 2) {
         // Click anywhere in scrollbar track area
         draggingThumb_ = true;
         dragStartY_ = e.y;
@@ -2244,7 +2254,7 @@ bool ScrollViewWidget::OnMouseDown(const MouseEvent& e) {
         float visH = VisibleHeight();
         float trackRange = visH - thumbH;
         if (trackRange > 0 && (e.y < thumb.top || e.y > thumb.bottom)) {
-            float targetY = e.y - thumbH / 2 - rect.top;
+            float targetY = e.y - thumbH / 2 - viewport.top;
             float maxScroll = contentHeight_ - visH;
             scrollY_ = targetY / (visH - thumbH) * maxScroll;
             ClampScroll();
@@ -2261,7 +2271,7 @@ bool ScrollViewWidget::OnMouseMove(const MouseEvent& e) {
     if (draggingThumb_) {
         float visH = VisibleHeight();
         float ratio = visH / contentHeight_;
-        float thumbH = std::max(20.0f, visH * ratio);
+        float thumbH = std::min(visH, std::max(20.0f, visH * ratio));
         float trackRange = visH - thumbH;
         if (trackRange > 0) {
             float dy = e.y - dragStartY_;
@@ -2273,7 +2283,10 @@ bool ScrollViewWidget::OnMouseMove(const MouseEvent& e) {
         return true;
     }
     // Detect hover over scrollbar area for visual width change (no layout impact)
-    hoveringBar_ = NeedsScrollbar() && hovered && e.x >= rect.right - kBarSpace - 2 && e.x < rect.right - 2;
+    const auto viewport = ViewportRect();
+    hoveringBar_ = NeedsScrollbar() && hovered &&
+        e.y >= viewport.top && e.y < viewport.bottom &&
+        e.x >= rect.right - kBarSpace - 2 && e.x < rect.right - 2;
     return hovered;
 }
 

--- a/src/ui/controls.h
+++ b/src/ui/controls.h
@@ -502,8 +502,10 @@ private:
 
     float ThumbWidth() const { return (hoveringBar_ || draggingThumb_) ? kThumbWide : kThumbThin; }
     void ClampScroll();
+    D2D1_RECT_F ViewportRect() const;
     float VisibleHeight() const;
     D2D1_RECT_F ThumbRect() const;
+    void DrawScrollbar(Renderer& r);
 };
 
 // ---- RadioButton ----

--- a/test/src/scroll_view_layout_test.cpp
+++ b/test/src/scroll_view_layout_test.cpp
@@ -1,0 +1,34 @@
+#include "controls.h"
+
+#include <cmath>
+#include <cstdio>
+#include <memory>
+
+int main() {
+    auto content = std::make_shared<ui::VBoxWidget>();
+    content->gap_ = 0.0f;
+
+    auto child = std::make_shared<ui::PanelWidget>();
+    child->fixedH = 90.0f;
+    content->AddChild(child);
+
+    ui::ScrollViewWidget scrollView;
+    scrollView.rect = {0.0f, 0.0f, 200.0f, 100.0f};
+    scrollView.padT = 10.0f;
+    scrollView.padB = 10.0f;
+    scrollView.SetContent(content);
+    scrollView.DoLayout();
+
+    if (!scrollView.NeedsScrollbar()) {
+        std::fputs("expected content to overflow the padded viewport\n", stderr);
+        return 1;
+    }
+
+    scrollView.SetScrollY(1000.0f);
+    if (std::fabs(scrollView.ScrollY() - 10.0f) > 0.01f) {
+        std::fprintf(stderr, "expected max scroll 10, got %.2f\n", scrollView.ScrollY());
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

- define one padding-aware inner viewport for ScrollView layout, scrolling, thumb geometry, and hit testing
- clip scrolled content to that inner viewport so it cannot paint into the padding area
- draw the overlay scrollbar after content so opaque children cannot cover it
- add a regression test for padded viewport overflow and maximum scroll range

## Bug

`DoLayout()` subtracted padding, while `VisibleHeight()`, clamping, and thumb calculations still used the outer widget height. A 100 px ScrollView with 10 px top/bottom padding therefore treated its viewport as 100 px instead of 80 px. Content near that boundary could fail to show a scrollbar or could not be scrolled fully into view.

The scrollbar was also painted before the child tree, despite being an overlay, so opaque content could cover it.

## Validation

The regression test uses a 100 px outer height, 10 px vertical padding on both sides, and 90 px content. It verifies that a scrollbar is required and the maximum scroll offset is 10 px. The test and optimized Windows x64 build pass under clang-cl.

Build: https://github.com/cdd1037/core-ui/actions/runs/32629855670